### PR TITLE
Adds config option to enable custom keyboard buttons

### DIFF
--- a/app/booth.js
+++ b/app/booth.js
@@ -49,14 +49,28 @@ camera.initialize(function( res, msg, err) {
   }
 });
 
-
 /*
  * Trigger photo when clicking / touching anywhere at the screen
  */
-$( "body" ).click(function() {
-  trigger();
-});
+if (!utils.getConfig().triggers ||
+    utils.getConfig().triggers.onClick ) {
+    $("body").click(function () {
+        trigger();
+    });
+}
 
+/*
+ * Custom User-definable Keyboard Triggers
+ */
+if( utils.getConfig().triggers &&
+    utils.getConfig().triggers.customKeys &&
+    utils.getConfig().triggers.customKeys.length > 0 ) {
+    $( "body" ).keydown(function(e) {
+        if( utils.getConfig().triggers.customKeys.indexOf( e.key ) !== -1 ) {
+            trigger();
+        }
+    });
+}
 
 /* Listen for pushbutton on GPIO 3 (PIN 5)
  * Activate the use of GPIOs by setting useGPIO in config.json to true.

--- a/config.json
+++ b/config.json
@@ -19,6 +19,10 @@
 		"capturetarget": 1,
 		"keep": true
 	},
+	"triggers": {
+		"onClick": true,
+		"customKeys": ["PageUp","PageDown","b"]
+	},
 	"content_dir": "../content",
 	"webapp": {
 		"password": "test",


### PR DESCRIPTION
As a user, I wanted to use Photo-Booth with a "Presentation" remote.  My remote had three buttons a forward, back and stop.  The usb device registers as a keyboard with "PageUp", "PageDown", and "b" respectively.  

Other users might want to make the "Space" bar trigger or "Enter".  This change lets them accomplish this by simply editing the array in triggers.customKeys