### PR TITLE
Update booth.js

### DIFF
--- a/app/booth.js
+++ b/app/booth.js
@@ -137,10 +137,14 @@ function trigger() {
         livePreview.stop();
       if (utils.getConfig().flash !== undefined && utils.getConfig().flash.enabled) {
         const flash = $("#flash");
-        flash.addClass("flash");
+        
+        setTimeout(function () {
+          flash.addClass("flash");
+        }, triggerPhotoOffsetBeforeZero*1000);
+      
         setTimeout(function () {
           flash.removeClass("flash");
-        }, 750);
+        }, (triggerPhotoOffsetBeforeZero*1000)+750);
       }
       camera.takePicture(function(res, msg1, msg2) {
 


### PR DESCRIPTION
Does not take the offset (triggerPhotoOffsetBeforeZero) into account and flash effect appears too early. (e.g. canon 500d needs an offset of 1.5 sec to switch from live view and take an image. -> flash appears in countdown between 2 and 1)
Fix: 
setTimeout(function () {
          flash.addClass("flash");
        }, triggerPhotoOffsetBeforeZero*1000);
      
        setTimeout(function () {
          flash.removeClass("flash");
        }, (triggerPhotoOffsetBeforeZero*1000)+750);
      }