### PR TITLE
Improved LivePreview

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Some notes:
 * The errorMessage is pure HTML, just fill in whatever you want
 * Live Preview works only on some cameras, see this [list](http://gphoto.org/proj/libgphoto2/support.php) and check if it lists "Liveview" for your model.
 * Slideshow and liveview do not work together.
-* You have to experiment with the framerate for live preview depending on the power of your machine. On a Notebook with an Intel i7-8550U upto 15% CPU utilization are needed for 20 frames per second. Also if your camera is running on battery, it drastically decreases the battery duration.
+* You have to experiment with the framerate for live preview depending on the power of your machine. On a Notebook with an Intel i7-8550U 7% CPU utilization are needed for 30 frames per second. On the RPI 3B+ 15 frames will run smoothly, with minor freezes sometimes, but it will result in a >90% CPU utilization of one core. Also if your camera is running on battery, it drastically decreases the battery duration.
 * When ``flash`` is set to `enabled` a white  page  will be shown as a flash after completing the countdown
 
 ### How to use the integrated webapp

--- a/app/css/main.css
+++ b/app/css/main.css
@@ -210,11 +210,8 @@ button {
     font-size: 5vw;
 }
 
-.live{
+#live{
     position: absolute; top: 0; bottom: 0; right: 0; left: 0;
-    background-repeat: no-repeat;
-    background-size: contain;
-    background-color: black;
 }
 
 .fa {


### PR DESCRIPTION
I never liked my first implementation of the live preview. Unfortunately the nodejs gphoto2 bindings and electron itself, are not ideal to work with in that regard. However I found one way, using a canvas instead of css background. It probably is faster, but it definitely is less buggy than the old implementation.

It is still not ideal, but the ideal way would require ffmpeg and maybe a gphoto2 binary.