### PR TITLE
Add configurable GPIO actions & photo series length

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ It looks like this:
 		"maxDownloadImageSize": 800,
 		"gifDelay": 1000,
 		"enableRemoteRelease": true,
-		"contactAddressType": "email"
+		"contactAddressType": "email",
+		"additionalShutterTriggers": [2, 3, 4]
 	},
 	"printing": {
 		"enabled": false,
@@ -185,6 +186,7 @@ Some notes:
 * When ``flash`` is set to `enabled` a white  page  will be shown as a flash after completing the countdown
 * You can use `gphoto2.simulate = true` when you want to test your setup without an active camera connection
 * The `webapp.contactAddressType` defines what kind of address types are supported inside the webapp. Supported values are `none` (feature disabled), `email` (email validation) and `text` (no input validation).
+* The `webapp.additionalShutterTriggers` adds additional remote release buttons with different series length
 
 ### How to use the integrated webapp
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,25 @@ It looks like this:
 		"keep": true,
 		"simulate": false
 	},
+	"GPIO": {
+		"enabled": false,
+		"actions": [
+			{
+				"channel": 3,
+				"action": "triggerPhoto",
+				"options": {
+					"photoSeriesLength": 4 // Optional, defaults to global photoSeriesLength
+				}
+			},
+			{
+				"channel": 5,
+				"action": "print",
+				"options": {
+					"layoutName": "selphy_1x1" // Layout key to use
+				}
+			}
+		]
+	},
 	"content_dir": null,
 	"webapp": {
 		"password": "test",
@@ -196,9 +215,47 @@ For an easy way to use it, start a open wifi hotspot on the computer photo-booth
 
 ## Use a push button to trigger photos
 
-You can connect a physical push button to the GPIO Pins of your Pi to trigger photos!
+You can connect a physical push button to the GPIO Pins of your Pi to trigger photos or print the last series of photos!
+The GPIO actions (and parameters) are configurable through `config.json` like this:
+```json
+"GPIO": {
+	"enabled": false,
+	"actions": [
+		{
+			"channel": 3,
+			"action": "triggerPhoto"
+		},
+		{
+			"channel": 5,
+			"action": "triggerPhoto",
+			"options": {
+				"photoSeriesLength": 4
+			}
+		},
+		{
+			"channel": 7,
+			"action": "print",
+			"options": {
+				"layoutName": "selphy_1x1"
+			}
+		},
+		{
+			"channel": 8,
+			"action": "print",
+			"options": {
+				"layoutName": "selphy_2x2"
+			}
+		}
+	]
+}
+```
+- When `enabled` is set to true, GPIO actions will be registered
+- Define all your actions inside `actions`. Be sure to set the `channel` to the right GPIO (eg. channel 3 for PIN 5).
+  There are 2 different actions available at the moment:
+  1. `triggerPhoto`: Will take a photo or a series of photos. Using the additional `photoSeriesLength` you can override the default count of photos being taken. This way you can have one button which takes a single picture and another which takes four pictures.
+  2. `print`: Will print the last photos taken. Define the desired layout using the `layoutName` option (see also `printing.layouts` options). The count of pictures will automaticaly be calculated using the selected layout size (image count).
 
-Therefore activate the GPIOs by setting `"useGPIO": true` in config.json. Then connect the first port of the push button to the ground pin of your Pi, second to GPIO 3 (PIN 5) and to a resistor of about 10k-100kΩ, the other end of the resistor to 3.3V (e.g. PIN 1). That's all!
+Connect the buttons like you configured the `GPIO.actions`. To use the channel 3 for example, connect the first port of the push button to the ground pin of your Pi, second to GPIO 3 (PIN 5) and to a resistor of about 10k-100kΩ, the other end of the resistor to 3.3V (e.g. PIN 1). That's all!
 
 **Make sure you run the application as root (`sudo npm start`), GPIOs need root privileges.**
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ As mentioned above photo-booth has a built in web page where images can be downl
 
 For an easy way to use it, start a open wifi hotspot on the computer photo-booth runs on. If you use a Raspberry Pi, there're enough tutorials out there to figure it out (i.e. [here](https://www.raspberrypi.org/documentation/configuration/wireless/access-point.md)). Then connect your device, e.g. a smartphone, with the wifi, open your browser and type in the ip address of the Pi. More elegant is it to configure a DNS redirect so the users can type in a web address like "photo.app", therefore I use `dnsmasq` which is also configured as DHCP server.
 
-## Use a push button to trigger photos
+## Use a push button to trigger photos / printouts
 
 You can connect a physical push button to the GPIO Pins of your Pi to trigger photos or print the last series of photos!
 The GPIO actions (and parameters) are configurable through `config.json` like this:

--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ It looks like this:
 		"width": "1440",
 		"height": "900",
 		"showDevTools": false,
-		"useGPIO": false,
 		"grayscaleMode": true,
 		"preventScreensaver": false
 	},

--- a/app/booth.js
+++ b/app/booth.js
@@ -116,7 +116,7 @@ function trigger(callback, seriesLength) {
 
   executing = true;
 
-  if (seriesLength === undefined) {
+  if (seriesLength === undefined || seriesLength === null) {
     seriesLength = photoSeriesLength;
   }
 
@@ -169,7 +169,7 @@ function trigger(callback, seriesLength) {
                 // end photo task after preview ended
                 executing = false;
                 if (++seriesCounter < seriesLength) {
-                  trigger(callback);
+                  trigger(callback, seriesLength);
                 } else {
                   seriesCounter = 0;
                   callback(true);
@@ -220,7 +220,7 @@ function trigger(callback, seriesLength) {
       if (res) {
 
         executing = false;
-        trigger(callback);
+        trigger(callback, seriesLength);
 
       } else {
         callback(false);

--- a/app/booth.js
+++ b/app/booth.js
@@ -104,7 +104,7 @@ const photoSeriesLength = utils.getConfig().photoSeriesLength ? Number(utils.get
 let executing = false;
 let seriesCounter = 0;
 
-function trigger(callback) {
+function trigger(callback, seriesLength) {
   if (callback === undefined) {
     callback = function() { };
   }
@@ -115,6 +115,10 @@ function trigger(callback) {
   }
 
   executing = true;
+
+  if (seriesLength === undefined) {
+    seriesLength = photoSeriesLength;
+  }
 
   slideshow.stop();
 
@@ -143,11 +147,11 @@ function trigger(callback) {
         livePreview.stop();
       if (utils.getConfig().flash !== undefined && utils.getConfig().flash.enabled) {
         const flash = $("#flash");
-        
+
         setTimeout(function () {
           flash.addClass("flash");
         }, triggerPhotoOffsetBeforeZero*1000);
-      
+
         setTimeout(function () {
           flash.removeClass("flash");
         }, (triggerPhotoOffsetBeforeZero*1000)+750);
@@ -164,7 +168,7 @@ function trigger(callback) {
               prompt = new PreviewPrompt(message1, photoPreviewDuration).start(false, false, function() {
                 // end photo task after preview ended
                 executing = false;
-                if (++seriesCounter < photoSeriesLength) {
+                if (++seriesCounter < seriesLength) {
                   trigger(callback);
                 } else {
                   seriesCounter = 0;
@@ -173,7 +177,7 @@ function trigger(callback) {
               });
 
               // Only add last image from series to collage
-              if(seriesCounter === photoSeriesLength-1) {
+              if(seriesCounter === seriesLength-1) {
                 setTimeout(function () {
                   utils.prependImage(message1);     // add image to collage
                 }, 1500);

--- a/app/booth.js
+++ b/app/booth.js
@@ -39,6 +39,7 @@ import {
 } from "./prompt.js";
 import slideshow from "./slideshow.js";
 
+import gpio from './gpio.js';
 import webApp from './webapp_server.js';
 
 const {getCurrentWindow, globalShortcut} = require('electron').remote;
@@ -80,21 +81,10 @@ if( utils.getConfig().triggers &&
     });
 }
 
-/* Listen for pushbutton on GPIO 3 (PIN 5)
- * Activate the use of GPIOs by setting useGPIO in config.json to true.
+/* Listen for pushbutton based on configured actions.
+ * Activate the use of GPIOs by setting GPIO.enabled in config.json to true.
  */
-if (utils.getConfig().init.useGPIO !== undefined ? utils.getConfig().init.useGPIO : true) {
-  console.log('GPIO usage activated');
-  const gpio = require('rpi-gpio');
-  gpio.setMode(gpio.MODE_BCM);
-  gpio.setup(3, gpio.DIR_IN, gpio.EDGE_BOTH);
-  gpio.on('change', function(channel, value) {
-    if (channel === 3 && !value) trigger();
-    // NOTE: takePhoto() is secure to don't run twice
-    // at the same time, make sure this is also so for
-    // your code.
-  });
-}
+gpio.initialize();
 
 const firstPhotoCountdownLength = utils.getConfig().firstPhotoCountdownLength ? Number(utils.getConfig().firstPhotoCountdownLength) : 5;
 const followingPhotosCountdownLength = utils.getConfig().followingPhotosCountdownLength ? Number(utils.getConfig().followingPhotosCountdownLength) : 3;

--- a/app/gpio.js
+++ b/app/gpio.js
@@ -1,0 +1,161 @@
+import fs from 'fs';
+import path from 'path';
+
+import booth from './booth.js';
+import utils from "./utils.js";
+import collage from './collage.js';
+import printer from './printer.js';
+
+class Gpio {
+    constructor() {
+        this._globalConfig = null;
+        this._config = null;
+        this._printRunning = false; // Prevent multiple printouts
+    }
+
+    initialize() {
+        this._loadConfig();
+
+        if (this._config.enabled) {
+            this._initGpio();
+        }
+    }
+
+    _loadConfig() {
+        this._globalConfig = utils.getConfig();
+        this._config = this._globalConfig.GPIO;
+
+        if (this._config != null) {
+            return;
+        }
+
+        // Migrate old settings
+        this._config = {};
+        this._config.enabled = this._globalConfig.init.useGPIO;
+        this._config.actions = [{
+            channel: 3,
+            action: 'triggerPhoto'
+        }];
+    }
+
+    _initGpio() {
+        console.log('GPIO usage activated');
+        const gpio = require('rpi-gpio');
+
+        gpio.setMode(gpio.MODE_BCM);
+
+        for (let action of this._config.actions) {
+            gpio.setup(action.channel, gpio.DIR_IN, gpio.EDGE_BOTH);
+        }
+
+        const that = this;
+        gpio.on('change', function(channel, value) {
+            that._gpioChange(channel, value);
+        });
+    }
+
+    _gpioChange(channel, value) {
+        if (value) {
+            return;
+        }
+
+        const actions = this._config.actions.filter(e => e.channel == channel);
+        for (let action of actions) {
+            this._executeAction(action);
+        }
+    }
+
+    // Make sure all actions don't run twice at the same time
+    _executeAction(action) {
+        console.log('GPIO action triggered', action.channel, action.action, action.options);
+
+        switch(action.action) {
+            case 'triggerPhoto':
+                this._triggerPhoto(action.options);
+                break;
+            case 'print':
+                this._print(action.options);
+                break;
+            default:
+                console.log('GPIO action not defined, action = ', action.action);
+        }
+    }
+
+    _triggerPhoto(options) {
+        const photoSeriesLength = options == null ? undefined : options.photoSeriesLength;
+        booth.triggerPhoto(function() { }, photoSeriesLength);
+    }
+
+    _print(options) {
+        options = options || { };
+
+        if (this._printRunning) {
+            return;
+        }
+
+        const printingConfig = this._globalConfig.printing || { };
+        if (!printingConfig.enabled) {
+            console.log('GPIO print not enabled');
+            return;
+        }
+
+        const layoutsConfig = printingConfig.layouts || [];
+        const layout = layoutsConfig.find(e => e.key === options.layoutName);
+        if (layout == null) {
+            console.log('GPIO print layout not found, layout = ', options.layoutName);
+            return;
+        }
+
+        const that = this;
+
+        this._printRunning = true;
+        const contentDir = utils.getPhotosDirectory();
+        fs.readdir(contentDir, function(err, files) {
+            if (err) {
+                console.log('GPIO print read files error', err);
+                that._printRunning = false;
+                return;
+            }
+
+            files = files.filter(file => file.toLowerCase().endsWith(".jpg") || file.toLowerCase().endsWith(".jpeg"));
+            files.sort();
+
+            const maxImagesCount = layout.options.width * layout.options.height;
+            const imagesToPrint = files.slice(-maxImagesCount);
+
+            const paths = imagesToPrint
+                .map(file => path.join(utils.getFullSizePhotosDirectory(), file));
+            console.log('files to print', paths);
+
+            collage.createCollage(layout.key, paths, function(err, collageFile) {
+                if (err) {
+                    console.log('GPIO print create collage error', err);
+                    that._printRunning = false;
+                    return;
+                }
+
+                console.log('GPIO printing image ', collageFile);
+
+                const contentDir = utils.getContentDirectory();
+                fs.appendFile(contentDir + '/print-log.txt', 'Print (GPIO)' + collageFile + '\n', function() { });
+
+                printer.print(collageFile, function(err, jobInfo) {
+                    that._printRunning = false;
+
+                    let logMessage = 'Print (GPIO) result of ' + collageFile + '\n';
+
+                    if (err) {
+                        logMessage += 'FAILED ' +  err.toString();
+                    } else {
+                        logMessage += 'SUCCESSFULL ' + JSON.stringify(jobInfo);
+                    }
+
+                    fs.appendFile(contentDir + '/print-log.txt', logMessage + '\n', function() { });
+                });
+            });
+        });
+    }
+}
+
+const gpio = new Gpio();
+export { gpio as default };

--- a/app/webapp_server.js
+++ b/app/webapp_server.js
@@ -253,8 +253,8 @@ io.on('connection', function(socket){
 		});
 	});
 
-	socket.on('trigger_photo', function(password){
-		console.log('trigger_photo');
+	socket.on('trigger_photo', function(password, seriesLength) {
+		console.log('trigger_photo', seriesLength);
 
 		if (utils.getConfig().webapp.enableRemoteRelease || passwordIsValid(password)) {
 			booth.triggerPhoto(function(success) {
@@ -263,7 +263,7 @@ io.on('connection', function(socket){
 				} else {
 					io.to(socket.id).emit('trigger_photo_error');
 				}
-			});
+			}, seriesLength);
 		}
 	});
 

--- a/app/webapp_server.js
+++ b/app/webapp_server.js
@@ -310,7 +310,7 @@ io.on('connection', function(socket){
 						io.to(socket.id).emit('print_success');
 					}
 
-					fs.appendFile(contentDir + '/print-log.txt', logMessage, function() { });
+					fs.appendFile(contentDir + '/print-log.txt', logMessage + '\n', function() { });
 				});
 			}
 		});

--- a/config.json
+++ b/config.json
@@ -5,7 +5,6 @@
 		"width": 1440,
 		"height": 900,
 		"showDevTools": false,
-		"useGPIO": false,
 		"grayscaleMode": true,
 		"preventScreensaver": true
 	},
@@ -23,6 +22,15 @@
 		"capturetarget": 1,
 		"keep": true,
 		"simulate": false
+	},
+	"GPIO": {
+		"enabled": false,
+		"actions": [
+			{
+				"channel": 3,
+				"action": "triggerPhoto"
+			}
+		]
 	},
 	"triggers": {
 		"onClick": true,

--- a/webapp/css/style.css
+++ b/webapp/css/style.css
@@ -86,6 +86,15 @@ nav .my-navbar .action-buttons a {
   display: none !important;
 }
 
+.action-buttons .badge {
+	position: relative;
+	top: -12px;
+	left: -16px;
+}
+
+.my-trigger-button:nth-child(2) .fa-camera {
+	margin-left: 25px;
+}
 
 /* -------------------- */
 

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -34,9 +34,15 @@
 		<div class="my-navbar row-fluid">
 			<a class="my-brand col-sm-4 col-xs-6" href="#"><b>photo-booth</b></a>
 			<div class="action-buttons col-sm-4 col-xs-6">
-				<a class="my-trigger-button" href="#" onclick="triggerPhoto()">
-					<i class="fa fa-camera hide" aria-hidden="true" id="trigger-button"></i>
+				<a class="my-trigger-button hide" href="#" onclick="triggerPhoto()">
+					<i class="fa fa-camera" aria-hidden="true"></i>
 				</a>
+				{{#each config.webapp.additionalShutterTriggers}}
+					<a class="my-trigger-button hide" href="#" onclick="triggerPhoto({{.}})">
+						<i class="fa fa-camera" aria-hidden="true"></i>
+						<span class="badge">{{.}}</span>
+					</a>
+				{{/each}}
 				<a class="my-gif-button" href="#">
 					<i class="fa fa-download hide" aria-hidden="true" id="gif-button"></i>
 				</a>

--- a/webapp/js/main.js
+++ b/webapp/js/main.js
@@ -99,9 +99,9 @@ function showSettings() {
 	}
 }
 
-function triggerPhoto() {
+function triggerPhoto(seriesLength) {
 	showPendingActionPage();
-	socket.emit('trigger_photo');
+	socket.emit('trigger_photo', null, seriesLength);
 }
 
 $('#auth-form').submit(function(){
@@ -135,7 +135,7 @@ socket.on('use grayscale', function() {
 });
 
 socket.on('enable remote release', function() {
-	$('#trigger-button').removeClass('hide');
+	$('.my-trigger-button').removeClass('hide');
 	$('.my-trigger-button').removeClass('hidden-xs')
 	$('.my-brand').addClass('hidden-xs');
 });


### PR DESCRIPTION
This pull request is based on the discussion of #95 with @rawbertp.

It currently includes the following changes:
- Configurable GPIO actions
  - *triggerPhoto* is the same as before but with the possibility to change the photo series length
  - *print* will print the last picture(s) based on the configured layout (1 picture layout will print the last picture only and a 4 picture layout will print the last 4 pictures)
  - This change is compatible with older configurations
- Configurable photo series length (more buttons in the webapp like *Take one picture* or *Take series of three pictures*)

**Note**: Because I don't have access to hardware buttons I won't be able to test the hardware related part of this change.