### PR TITLE
Fix broken link to "how to set up the Pi as a wireless access point" …

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Some notes:
 
 As mentioned above photo-booth has a built in web page where images can be downloaded, gif animations can be created and images can be printed.
 
-For an easy way to use it, start a open wifi hotspot on the computer photo-booth runs on. If you use a Raspberry Pi, there're enough tutorials out there to figure it out (i.e. [here](https://www.raspberrypi.org/documentation/configuration/wireless/access-point.md)). Then connect your device, e.g. a smartphone, with the wifi, open your browser and type in the ip address of the Pi. More elegant is it to configure a DNS redirect so the users can type in a web address like "photo.app", therefore I use `dnsmasq` which is also configured as DHCP server.
+For an easy way to use it, start a open wifi hotspot on the computer photo-booth runs on. If you use a Raspberry Pi, there're enough tutorials out there to figure it out (i.e. [here](https://www.raspberrypi.org/documentation/configuration/wireless/access-point-routed.md)). Then connect your device, e.g. a smartphone, with the wifi, open your browser and type in the ip address of the Pi. More elegant is it to configure a DNS redirect so the users can type in a web address like "photo.app", therefore I use `dnsmasq` which is also configured as DHCP server.
 
 ## Use a push button to trigger photos
 


### PR DESCRIPTION
…in the README

The raspberrypi.org/documentation about access point setup was split
into "Routed access point" and "Bridged access point". The
"Routed access point" might be appropriate in the most use cases.